### PR TITLE
Simulation Polish

### DIFF
--- a/components/simulation/Simulation.jsx
+++ b/components/simulation/Simulation.jsx
@@ -231,6 +231,7 @@ const Simulation = ({ data }) => {
             <Slider
               id="inputAge"
               {...section.inputs["age"]}
+              modifier={(value) => `${value}+`}
               value={inputs["inputAge"]}
               onChange={updateInputs}
             />
@@ -243,6 +244,7 @@ const Simulation = ({ data }) => {
             <Slider
               id="inputR"
               {...section.inputs["r"]}
+              modifier={(value) => `${value * 100}%`}
               value={inputs["inputR"]}
               onChange={updateInputs}
             />
@@ -256,7 +258,7 @@ const Simulation = ({ data }) => {
 
             <div
               className={`${styles.secondaryInputs} ${
-                showSecondaryInputs ? styles.show : styles.hide
+                showSecondaryInputs ? styles.expanded : styles.hide
               }`}
             >
               <Slider
@@ -336,7 +338,15 @@ const Simulation = ({ data }) => {
               <div className={styles.outputInnerContainer}>
                 <div className={styles.Item}>
                   <span className={styles.outputStat}>
-                    {outputs.outputNPV || 0}
+                    ${outputs.outputGDP20 || 0}B
+                  </span>
+                  <div className={styles.outputLabel}>
+                    Yearly gain to U.S. GDP (average over 2045-2065)
+                  </div>
+                </div>
+                <div className={styles.Item}>
+                  <span className={styles.outputStat}>
+                    ${outputs.outputNPV || 0}T
                   </span>
                   <div className={styles.outputLabel}>
                     Long-term return, (Net Present Value over decades)
@@ -344,19 +354,10 @@ const Simulation = ({ data }) => {
                 </div>
                 <div className={styles.Item}>
                   <span className={styles.outputStat}>
-                    {outputs.outputGDP20 || 0}
+                    {outputs.outputPop || 0}k
                   </span>
                   <div className={styles.outputLabel}>
-                    Yearly GDP change, Billions of 2025$ (average over
-                    2045-2065)
-                  </div>
-                </div>
-                <div className={styles.Item}>
-                  <span className={styles.outputStat}>
-                    {outputs.outputPop || 0}
-                  </span>
-                  <div className={styles.outputLabel}>
-                    Lives saved by 2050 (thousands of people)
+                    Lives saved or gain (by 2050)
                   </div>
                 </div>
               </div>

--- a/components/simulation/Simulation.jsx
+++ b/components/simulation/Simulation.jsx
@@ -349,7 +349,7 @@ const Simulation = ({ data }) => {
                     ${outputs.outputNPV || 0}T
                   </span>
                   <div className={styles.outputLabel}>
-                    Long-term return, (Net Present Value over decades)
+                    Long-term return (Net Present Value over decades)
                   </div>
                 </div>
                 <div className={styles.Item}>

--- a/components/simulation/Simulation.module.scss
+++ b/components/simulation/Simulation.module.scss
@@ -133,7 +133,7 @@
 }
 
 .expanded {
-  max-height: 500px; /* Adjust based on content */
+  max-height: 500px;
   opacity: 1;
 }
 

--- a/components/simulation/Simulation.module.scss
+++ b/components/simulation/Simulation.module.scss
@@ -129,7 +129,9 @@
   max-height: 0;
 
   opacity: 0;
-  transition: opacity 0.3s ease-out;
+  transition:
+    opacity 0.3s ease-out,
+    max-height 0.3s ease-out;
 }
 
 .expanded {

--- a/components/simulation/Slider.jsx
+++ b/components/simulation/Slider.jsx
@@ -11,6 +11,7 @@ const Slider = ({
   min,
   max,
   step,
+  modifier,
   onChange,
   tooltip,
 }) => {
@@ -54,7 +55,7 @@ const Slider = ({
         </div>
         <div className={styles.value_wrapper}>
           <div className={styles.value} style={{ left: `${progress * 100}%` }}>
-            {value}
+            {modifier ? modifier(value) : value}
           </div>
         </div>
       </div>


### PR DESCRIPTION
- [x] In the simulation tool, the discount rate should be in % (2%, 4%, etc)
- [x] Can we include the units in the output? 
- [x] Include a "+" after the input number below the slider, so for this slider, it's clear that we're talking about age X and up.
- [x] Secondary inputs not expanding
