### PR TITLE
Allow brioche app origin in CORS permissions

### DIFF
--- a/fastapi-backend/app.py
+++ b/fastapi-backend/app.py
@@ -115,8 +115,8 @@ def load_models():
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # Next.js dev server
-    # allow_origins=["*"],
+    # allow_origins=["http://localhost:3000"],  # for local Next.js dev server
+    allow_origins=["https://profound-brioche-f9933d.netlify.app/"], # for brioche app
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
This PR updates the origins for API calls to allow calls from the front end served on brioche.

cc @zscheinfeld @rickecon 