### PR TITLE
Update CORS methods

### DIFF
--- a/fastapi-backend/app.py
+++ b/fastapi-backend/app.py
@@ -115,10 +115,12 @@ def load_models():
 
 app.add_middleware(
     CORSMiddleware,
-    # allow_origins=["http://localhost:3000"],  # for local Next.js dev server
-    allow_origins=["http://localhost:3000", "https://profound-brioche-f9933d.netlify.app/"],
+    allow_origins=[
+        "http://localhost:3000",
+        "https://profound-brioche-f9933d.netlify.app"
+        ],
     allow_credentials=True,
-    allow_methods=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
The API was not responding to the netlify app.  The error message was:
```
profound-brioche-f9933d.netlify.app/:1 Access to fetch at 'https://fastapi-backend-proud-tree-3049.fly.dev/predict' from origin 'https://profound-brioche-f9933d.netlify.app' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

This PR updates the CORS methods to:
1. Drop the trailing slash from the netlify.app url
2. Be specific about the allowed methods.